### PR TITLE
fix: return csv_reason in advice api payload

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -20,19 +20,22 @@ Retrieves context-aware medical advice based on air quality and user profile.
 | `stationName` | String | Station name for Air Quality lookup | `"강남구"` |
 | `userProfile` | Object | User's health profile | See below |
 
-**`userProfile` Schema:**
+**`userProfile` Schema (canonical values):**
 ```json
 {
-  "ageGroup": "infant" | "elementary_low" | "elementary_high" | "teen",
-  "condition": "asthma" | "rhinitis" | "none" | "etc"
+  "ageGroup": "infant" | "toddler" | "elementary_low" | "elementary_high" | "teen_adult",
+  "condition": "general" | "rhinitis" | "asthma" | "atopy"
 }
 ```
 
-**`ageGroup` Label Guide (KR):**
-- `infant`: 유아
+Aliases like `teen`, `none`, `healthy`, `normal`, `일반` are accepted and normalized internally.
+
+**`ageGroup` Label Guide (KR, canonical):**
+- `infant`: 영아(0-2세)
+- `toddler`: 유아(3-6세)
 - `elementary_low`: 초등 저학년
 - `elementary_high`: 초등 고학년
-- `teen`: 청소년
+- `teen_adult`: 청소년/성인
 
 ### Example Request
 ```bash
@@ -47,35 +50,164 @@ curl -X POST "https://<your-domain>/api/advice" \
 ### Example Response
 ```json
 {
-  "decision": "오늘은 실내가 더 편해요 🏠",
+  "decision": "실내 놀이가 더 안전해요",
+  "csv_reason": "초미세먼지 농도가 높아 호흡기 자극 위험이 커졌어요.",
+  "reason": "초미세먼지와 오존 수준을 기준으로 행동 지침을 안내합니다.",
   "three_reason": [
-    "현재 미세먼지가 **나쁨** 수준이라 호흡기가 예민할 수 있어요.",
-    "특히 **천식**이 있다면 기도가 수축될 위험이 높습니다.",
-    "오늘은 **실외 활동**을 자제하고 마스크를 꼭 챙겨주세요."
+    "현재 **초미세먼지**가 높아 **호흡기 자극** 위험이 커졌어요.",
+    "특히 **천식**이 있다면 증상이 악화될 수 있어요.",
+    "오늘은 **실외 활동**을 줄이고 실내 공기질 관리가 필요해요."
   ],
-  "detail_answer": "현재 미세먼지 농도가 나쁨 수준이며, 천식 환자에게는 위험할 수 있습니다. 온도와 습도를 고려할 때 기도가 더욱 민감해질 수 있으므로, 실외 활동을 최소화하고 실내에서 안전하게 지내는 것이 좋습니다.",
+  "detail_answer": "현재 대기질과 사용자 프로필을 종합하면 실외 노출 최소화가 권장됩니다.",
   "actionItems": [
-    "외출 대신 장난감 정리+찾기 게임",
-    "실내에서 풍선배구/장애물 코스(가볍게)",
-    "환기는 짧게(5–10분) 하고 바로 닫기"
+    "외출 대신 실내 활동으로 대체하기",
+    "환기는 짧게 하고 즉시 닫기",
+    "귀가 후 손/얼굴 세정하기"
   ],
   "references": [
     "질병관리청 미세먼지 대응지침 2024",
     "천식 및 알레르기 학회 가이드라인"
-  ]
+  ],
+  "pm25_value": 51,
+  "pm10_value": 72,
+  "o3_value": 0.041,
+  "no2_value": 0.019
 }
 ```
 
 **Response Fields:**
-- `decision` (String): Short decision text from the system
-- `three_reason` (Array[String]): 3 concise summary points with `**keyword**` markers for frontend highlighting
-- `detail_answer` (String): Detailed medical explanation
-- `actionItems` (Array[String]): Recommended action items
-- `references` (Array[String]): Source references from medical guidelines
+- `decision` (String): CSV `메인문구` 기반의 최종 결정 문구
+- `csv_reason` (String | null): CSV `이유` 컬럼 값
+- `reason` (String | null): `detail_answer`와 동일한 상세 설명(호환용)
+- `three_reason` (Array[String]): 3개 핵심 요약 문장
+- `detail_answer` (String): 상세 설명
+- `actionItems` (Array[String]): CSV `행동1~3` 기반 행동 지침
+- `references` (Array[String]): 벡터 검색으로 참조된 출처
+- `pm25_value`, `pm10_value`, `o3_value`, `no2_value` (Number): 현재 대기질 수치(실행 시점에 포함될 수 있음)
+
+### CSV Mapping Rule
+`/api/advice`는 CSV 컬럼명을 그대로 반환하지 않고 아래처럼 매핑해서 반환합니다.
+
+| CSV Column | Returned Field | Returned? | Notes |
+|---|---|---|---|
+| `대기등급` | - | No | 내부에서 최종 등급 계산에 사용 |
+| `메인문구` | `decision` | Yes | 핵심 결정 문구 |
+| `연령대` | - | No | 요청 `userProfile.ageGroup`으로 입력받아 사용 |
+| `이유` | `csv_reason` | Yes | CSV 근거 문장 |
+| `질환군` | - | No | 요청 `userProfile.condition`으로 입력받아 사용 |
+| `행동1` | `actionItems[0]` | Yes | 행동 지침 배열 |
+| `행동2` | `actionItems[1]` | Yes | 행동 지침 배열 |
+| `행동3` | `actionItems[2]` | Yes | 행동 지침 배열 |
+
+Note: `ageGroup=infant`인 경우 `actionItems` 맨 앞에 `"※ 주의: 마스크 착용 금지(질식 위험)"` 경고 문구가 추가될 수 있습니다.
 
 ---
 
-## 2. Ingest PDF (Single File)
+## 2. Get Air Quality
+Returns latest air quality snapshot for a station (with internal fallback chain).
+
+- **Endpoint:** `GET /api/air-quality`
+- **Query Parameters:**
+
+| Field | Type | Required | Description | Example |
+|---|---|---|---|---|
+| `stationName` | String | Yes | 측정소/지역명 | `"종로구"` |
+
+### Example Request
+```bash
+curl -G "https://<your-domain>/api/air-quality" \
+  --data-urlencode "stationName=종로구"
+```
+
+### Example Response
+```json
+{
+  "stationName": "종로구",
+  "sidoName": "서울",
+  "pm25_value": 23,
+  "pm10_value": 41,
+  "o3_value": 0.031,
+  "no2_value": 0.018,
+  "co_value": 0.5,
+  "so2_value": 0.003,
+  "pm25_grade": "보통",
+  "pm10_grade": "보통",
+  "o3_grade": "보통",
+  "no2_grade": "좋음",
+  "co_grade": "좋음",
+  "so2_grade": "좋음",
+  "temp": 22.0,
+  "humidity": 45.0,
+  "dataTime": "2026-03-03 13:00"
+}
+```
+
+**Response Fields:**
+- `stationName` (String): 최종 매칭된 측정소명
+- `sidoName` (String | null): 시/도명
+- `pm25_value`, `pm10_value`, `o3_value`, `no2_value`, `co_value`, `so2_value` (Number): 오염물질 수치
+- `pm25_grade`, `pm10_grade`, `o3_grade`, `no2_grade`, `co_grade`, `so2_grade` (String): 4단계 등급(`좋음/보통/나쁨/매우나쁨`)
+- `temp` (Number): 기온
+- `humidity` (Number): 습도
+- `dataTime` (String | null): 관측 시각
+
+**Status Codes:**
+- `200`: 정상 반환
+- `404`: 해당 측정소 데이터 없음
+- `500`: 내부 오류
+
+동작 우선순위:
+1. MongoDB `air_quality_data` 최신 데이터
+2. Air Korea fallback API
+3. Mock data fallback
+
+---
+
+## 3. Clothing Recommendation (Rule-based)
+현재 버전은 기온/습도 규칙 기반 옷차림 추천을 제공합니다.
+
+- **Endpoint:** `POST /api/clothing-recommendation`
+- **Content-Type:** `application/json`
+
+### Request Body
+| Field | Type | Description |
+|-------|------|-------------|
+| `temperature` | Number | 기온 (기본값: `22.0`) |
+| `humidity` | Number | 습도 (기본값: `45.0`) |
+
+### Example Request
+```bash
+curl -X POST "https://<your-domain>/api/clothing-recommendation" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "temperature": 26.1,
+    "humidity": 71
+  }'
+```
+
+### Example Response
+```json
+{
+  "summary": "다소 덥고 습한 날씨예요. 통풍이 잘되는 옷차림을 추천해요.",
+  "recommendation": "반팔 + 얇은 바람막이 + 통풍 좋은 긴바지를 추천해요.",
+  "tips": [
+    "바깥 활동 후 겉옷을 바로 털고 손/얼굴을 씻어주세요.",
+    "땀을 빨리 말리는 소재를 선택하세요."
+  ],
+  "comfortLevel": "WARM",
+  "temperature": 26.1,
+  "humidity": 71.0,
+  "source": "rule-based-v1"
+}
+```
+
+동작:
+- 현재 구현은 규칙 기반으로만 동작합니다.
+- 서버 오류 시 `source: "fallback"` 응답으로 대체됩니다.
+
+---
+
+## 4. Ingest PDF (Single File)
 Uploads a single PDF file to the vector database.
 
 - **Endpoint:** `POST /api/ingest/pdf`
@@ -102,7 +234,7 @@ curl -X POST -F "file=@/path/to/paper.pdf" "https://<your-domain>/api/ingest/pdf
 
 ---
 
-## 3. OpenAI Responses Proxy (Server-to-Server)
+## 5. OpenAI Responses Proxy (Server-to-Server)
 OpenAI Responses API 호출을 이 서버가 중계합니다.
 
 - **Health Endpoint:** `GET /api/openai/v1/health`

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ sequenceDiagram
   - `medical_guidelines`: 임베딩 포함 가이드라인/문서
   - `daily_air_quality`: 날짜별 대기질 데이터
   - `rag_cache`: 사용자/대기질 기반 캐시
-- **결정 로직**: PM2.5, O3 등급 기반으로 `ok/caution/warning` 산출
+- **결정 로직**: PM2.5/PM10/O3 및 보정 로직을 반영한 4단계(`좋음/보통/나쁨/매우나쁨`) 등급으로 CSV 80행 매트릭스 매핑
 - **응답 구성**: 결정 텍스트 + 행동 지침(템플릿) + LLM reason
 - **폴백 로직**: 캐시 실패, 벡터 검색 실패, LLM 실패에 대한 안전 장치 포함
 
@@ -135,17 +135,84 @@ sequenceDiagram
 - **Request Body**
   - `stationName` (String): 대기질 측정소명
   - `userProfile` (Object)
-    - `ageGroup`: `"infant" | "elementary_low" | "elementary_high" | "teen"`
-    - `condition`: `"asthma" | "rhinitis" | "none" | "etc"`
+    - `ageGroup`: `"infant" | "toddler" | "elementary_low" | "elementary_high" | "teen_adult"`
+    - `condition`: `"general" | "rhinitis" | "asthma" | "atopy"`
 - **Response**
   - `decision`: String (결정 문구)
-  - `reason`: String (LLM 생성 근거)
+  - `csv_reason`: String | null (CSV `이유` 컬럼)
+  - `reason`: String | null (`detail_answer`와 동일한 호환 필드)
+  - `three_reason`: String[] (3개 요약 문장)
+  - `detail_answer`: String (상세 설명)
   - `actionItems`: String[] (행동 지침)
   - `references`: String[] (가이드라인 출처)
+  - `pm25_value`, `pm10_value`, `o3_value`, `no2_value`: Number (실행 시점에 포함될 수 있음)
 - **Error**
   - `500`: 내부 오류 (결정/근거 생성 실패)
 
-### 3) Ingest PDF (Single File)
+CSV 컬럼 반환 규칙:
+- `메인문구` -> `decision`
+- `이유` -> `csv_reason`
+- `행동1~3` -> `actionItems`
+- `대기등급`, `연령대`, `질환군`은 응답에 직접 반환하지 않음
+
+### 3) Get Air Quality
+
+- **GET** `/api/air-quality`
+- **Query Parameters**
+  - `stationName` (String, required): 측정소/지역명
+- **Response**
+  - `stationName`: String
+  - `sidoName`: String | null
+  - `pm25_value`, `pm10_value`, `o3_value`, `no2_value`, `co_value`, `so2_value`: Number
+  - `pm25_grade`, `pm10_grade`, `o3_grade`, `no2_grade`, `co_grade`, `so2_grade`: String (`좋음/보통/나쁨/매우나쁨`)
+  - `temp`: Number
+  - `humidity`: Number
+  - `dataTime`: String | null
+- **Status**
+  - `200`: 정상 반환
+  - `404`: 해당 측정소 데이터 없음
+  - `500`: 내부 오류
+- **동작 우선순위**
+  1. MongoDB `air_quality_data`
+  2. Air Korea fallback API
+  3. Mock data fallback
+
+예시:
+```bash
+curl -G "https://<your-domain>/api/air-quality" \
+  --data-urlencode "stationName=종로구"
+```
+
+### 4) Clothing Recommendation (Rule-based)
+
+- **POST** `/api/clothing-recommendation`
+- **Content-Type**: `application/json`
+- **Request Body**
+  - `temperature` (Number, optional, default `22.0`)
+  - `humidity` (Number, optional, default `45.0`)
+- **Response**
+  - `summary`: String
+  - `recommendation`: String
+  - `tips`: String[]
+  - `comfortLevel`: `"FREEZING" | "COLD" | "CHILLY" | "MILD" | "WARM" | "HOT"`
+  - `temperature`: Number
+  - `humidity`: Number
+  - `source`: String (`rule-based-v1` 또는 오류 시 `fallback`)
+- **동작 규칙**
+  - 현재 구현은 규칙 기반 추천을 반환
+  - 서버 오류 시 fallback 응답 반환
+
+예시:
+```bash
+curl -X POST "https://<your-domain>/api/clothing-recommendation" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "temperature": 27.3,
+    "humidity": 68
+  }'
+```
+
+### 5) Ingest PDF (Single File)
 
 - **POST** `/api/ingest/pdf`
 - **Content-Type**: `multipart/form-data`
@@ -159,7 +226,7 @@ sequenceDiagram
   - `400`: PDF가 아닌 파일 업로드
   - `500`: 처리 실패
 
-### 4) OpenAI Responses Proxy (Server-to-Server)
+### 6) OpenAI Responses Proxy (Server-to-Server)
 
 - **GET** `/api/openai/v1/health`
 - **Response**

--- a/app/services.py
+++ b/app/services.py
@@ -435,6 +435,205 @@ def get_clothing_recommendation(temp: Any, humidity: Any) -> Dict[str, Any]:
     }
 
 
+AGE_GROUP_LABELS = {
+    "infant": "영아(0-2세)",
+    "toddler": "유아(3-6세)",
+    "elementary_low": "초등저(7-9세)",
+    "elementary_high": "초등고(10-12세)",
+    "teen_adult": "청소년/성인",
+}
+
+CONDITION_LABELS = {
+    "general": "일반",
+    "rhinitis": "비염",
+    "asthma": "천식",
+    "atopy": "아토피",
+}
+
+VALID_COMFORT_LEVELS = {"FREEZING", "COLD", "CHILLY", "MILD", "WARM", "HOT"}
+
+
+def _normalize_condition_key(condition: Any) -> str:
+    if condition is None:
+        return "general"
+    raw = str(condition).strip().lower()
+    if not raw:
+        return "general"
+
+    alias_map = {
+        "general": {"general", "일반", "none", "없음", "healthy", "normal", "건강함"},
+        "rhinitis": {"rhinitis", "비염", "allergic_rhinitis", "allergy"},
+        "asthma": {"asthma", "천식"},
+        "atopy": {"atopy", "아토피", "eczema"},
+    }
+    for key, aliases in alias_map.items():
+        if raw in aliases:
+            return key
+
+    if "비염" in raw or "rhinitis" in raw:
+        return "rhinitis"
+    if "천식" in raw or "asthma" in raw:
+        return "asthma"
+    if "아토피" in raw or "atopy" in raw or "eczema" in raw:
+        return "atopy"
+    return "general"
+
+
+def _normalize_grade_label(value: Any, default: Optional[str] = "보통") -> Optional[str]:
+    if value is None:
+        return default
+    raw = str(value).strip()
+    if not raw:
+        return default
+
+    compact = raw.lower().replace(" ", "").replace("-", "").replace("_", "")
+    alias_map = {
+        "1": "좋음",
+        "good": "좋음",
+        "좋음": "좋음",
+        "2": "보통",
+        "moderate": "보통",
+        "normal": "보통",
+        "보통": "보통",
+        "3": "나쁨",
+        "bad": "나쁨",
+        "poor": "나쁨",
+        "나쁨": "나쁨",
+        "4": "매우나쁨",
+        "verybad": "매우나쁨",
+        "verypoor": "매우나쁨",
+        "매우나쁨": "매우나쁨",
+    }
+    return alias_map.get(compact, default)
+
+
+def _resolve_air_grades(air_quality: Optional[Dict[str, Any]]) -> Dict[str, str]:
+    payload = air_quality or {}
+    overall = _normalize_grade_label(payload.get("grade"), default=None)
+    pm25 = _normalize_grade_label(payload.get("pm25Grade"), default=None)
+    pm10 = _normalize_grade_label(payload.get("pm10Grade"), default=None)
+    o3 = _normalize_grade_label(payload.get("o3Grade"), default=None)
+
+    if overall is None:
+        known_grades = [g for g in [pm25, pm10, o3] if g]
+        if known_grades:
+            overall = max(known_grades, key=lambda grade: GRADE_MAP.get(grade, 2))
+        else:
+            overall = "보통"
+
+    return {
+        "overall": overall,
+        "pm25": pm25 or overall,
+        "pm10": pm10 or overall,
+        "o3": o3 or overall,
+    }
+
+
+def get_ai_clothing_recommendation(
+    temp: Any,
+    humidity: Any,
+    user_profile: Optional[Dict[str, Any]] = None,
+    air_quality: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    fallback_result = get_clothing_recommendation(temp, humidity)
+    user_profile = user_profile or {}
+    air_quality = air_quality or {}
+
+    has_profile_input = bool(user_profile.get("ageGroup")) or bool(user_profile.get("condition"))
+    has_air_input = any(air_quality.get(key) for key in ("grade", "pm25Grade", "pm10Grade", "o3Grade"))
+    if not (has_profile_input and has_air_input):
+        return fallback_result
+
+    if not openai_client:
+        fallback_no_ai = dict(fallback_result)
+        fallback_no_ai["source"] = "rule-based-fallback-no-openai"
+        return fallback_no_ai
+
+    age_group_key = _normalize_age_group(user_profile.get("ageGroup"))
+    condition_key = _normalize_condition_key(user_profile.get("condition"))
+    age_group_label = AGE_GROUP_LABELS.get(age_group_key, AGE_GROUP_LABELS["elementary_high"])
+    condition_label = CONDITION_LABELS.get(condition_key, CONDITION_LABELS["general"])
+    air_grades = _resolve_air_grades(air_quality)
+
+    system_prompt = """
+    너는 날씨/대기질/연령/기저질환을 함께 반영해 실용적인 옷차림을 추천하는 AI 스타일 코치다.
+    출력은 반드시 JSON 객체 하나만 반환한다.
+    필수 키:
+    - summary: 한 문장 요약
+    - recommendation: 핵심 착장 한 문장
+    - tips: 1~3개의 짧은 실천 팁 배열
+    - comfortLevel: FREEZING|COLD|CHILLY|MILD|WARM|HOT 중 하나
+    규칙:
+    - 입력 수치와 모순된 추천을 하지 말 것
+    - 과도한 의료 지시는 피할 것
+    - 한국어로 간결하고 즉시 실행 가능하게 작성할 것
+    """
+
+    user_prompt = f"""
+    [입력]
+    - 기온: {fallback_result.get("temperature")}°C
+    - 습도: {fallback_result.get("humidity")}%
+    - 연령대: {age_group_label}
+    - 기저질환: {condition_label}
+    - 대기등급(종합): {air_grades["overall"]}
+    - PM2.5 등급: {air_grades["pm25"]}
+    - PM10 등급: {air_grades["pm10"]}
+    - 오존(O3) 등급: {air_grades["o3"]}
+
+    [규칙기반 참고안]
+    - summary: {fallback_result.get("summary")}
+    - recommendation: {fallback_result.get("recommendation")}
+    - tips: {fallback_result.get("tips")}
+    - comfortLevel: {fallback_result.get("comfortLevel")}
+
+    위 정보를 바탕으로 개인화된 옷차림을 생성해줘.
+    """
+
+    try:
+        response = openai_client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt}
+            ],
+            response_format={"type": "json_object"},
+            temperature=0.7
+        )
+        content = response.choices[0].message.content or "{}"
+        llm_result = json.loads(content)
+
+        summary = str(llm_result.get("summary", "")).strip()
+        recommendation = str(llm_result.get("recommendation", "")).strip()
+        raw_tips = llm_result.get("tips")
+        tips = []
+        if isinstance(raw_tips, list):
+            for item in raw_tips:
+                text = str(item).strip()
+                if text:
+                    tips.append(text)
+        comfort_level = str(llm_result.get("comfortLevel", "")).strip().upper()
+
+        if not summary or not recommendation or not tips:
+            raise ValueError("LLM response missing required clothing fields")
+        if comfort_level not in VALID_COMFORT_LEVELS:
+            comfort_level = fallback_result.get("comfortLevel", "MILD")
+
+        return {
+            "summary": summary,
+            "recommendation": recommendation,
+            "tips": tips[:3],
+            "comfortLevel": comfort_level,
+            "temperature": fallback_result.get("temperature"),
+            "humidity": fallback_result.get("humidity"),
+            "source": "ai-dynamic-v1"
+        }
+    except Exception as e:
+        print(f"Error generating AI clothing recommendation: {e}")
+        fallback_error = dict(fallback_result)
+        fallback_error["source"] = "rule-based-fallback-on-error"
+        return fallback_error
+
+
 CSV_AGE_MAP = {
     "영아(0-2세)": "infant",
     "유아(3-6세)": "toddler",

--- a/app/services.py
+++ b/app/services.py
@@ -1426,6 +1426,8 @@ async def get_medical_advice(station_name: str, user_profile: Dict[str, Any]) ->
         # Merge Results
         final_result = {
             "decision": decision_text,
+            "csv_reason": csv_reason,
+            "reason": llm_result.get("detail_answer", "정보를 불러오는 중 문제가 발생했습니다."),
             "three_reason": llm_result.get("three_reason", [
                 "대기질 정보를 분석하고 있습니다.",
                 "잠시 후 다시 확인해주세요.",
@@ -1460,6 +1462,8 @@ async def get_medical_advice(station_name: str, user_profile: Dict[str, Any]) ->
         # Fallback even if LLM fails, we satisfy the deterministic requirement
         return {
             "decision": decision_text,
+            "csv_reason": csv_reason,
+            "reason": "일시적인 오류로 상세 설명을 불러오지 못했습니다. 하지만 행동 지침은 위와 같이 준수해주세요.",
             "three_reason": [
                 "일시적인 오류로 상세 분석을 불러오지 못했습니다.",
                 "하지만 **행동 지침**은 위와 같이 준수해주세요.",

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 import uvicorn
 import os
 from contextlib import asynccontextmanager
@@ -17,6 +17,8 @@ class AdviceRequest(BaseModel):
 # Define Response Model
 class AdviceResponse(BaseModel):
     decision: str
+    csv_reason: Optional[str] = None
+    reason: Optional[str] = None
     three_reason: List[str]  # 3 bullet points with **keyword** highlighting
     detail_answer: str       # Detailed medical explanation
     actionItems: List[str]

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import uvicorn
 import os
 from contextlib import asynccontextmanager
 
-from app.services import get_medical_advice, ingest_pdf, db, get_clothing_recommendation
+from app.services import get_medical_advice, ingest_pdf, db, get_ai_clothing_recommendation
 from app.openai_proxy import router as openai_proxy_router
 
 # Define Request Model
@@ -28,6 +28,9 @@ class AdviceResponse(BaseModel):
 class ClothingRecommendationRequest(BaseModel):
     temperature: float = 22.0
     humidity: float = 45.0
+    userProfile: Optional[Dict[str, Any]] = None
+    airQuality: Optional[Dict[str, Any]] = None
+    airGrade: Optional[str] = None
 
 
 class ClothingRecommendationResponse(BaseModel):
@@ -111,7 +114,16 @@ async def get_air_quality_endpoint(stationName: str):
 @app.post("/api/clothing-recommendation", response_model=ClothingRecommendationResponse)
 async def clothing_recommendation(request: ClothingRecommendationRequest):
     try:
-        result = get_clothing_recommendation(request.temperature, request.humidity)
+        air_quality = dict(request.airQuality or {})
+        if request.airGrade and not air_quality.get("grade"):
+            air_quality["grade"] = request.airGrade
+
+        result = get_ai_clothing_recommendation(
+            request.temperature,
+            request.humidity,
+            user_profile=request.userProfile,
+            air_quality=air_quality,
+        )
         return JSONResponse(content=result)
     except Exception as e:
         print(f"Error generating clothing recommendation: {e}")

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   ],
   "functions": {
     "main.py": {
-      "maxDuration": 800
+      "maxDuration": 300
     }
   },
   "routes": [

--- a/vercel.json
+++ b/vercel.json
@@ -5,11 +5,6 @@
       "use": "@vercel/python"
     }
   ],
-  "functions": {
-    "main.py": {
-      "maxDuration": 300
-    }
-  },
   "routes": [
     {
       "src": "/(.*)",


### PR DESCRIPTION
## 변경 사항
- Advice API 응답 모델(`AdviceResponse`)에 `csv_reason`, `reason` 필드를 추가
- `get_medical_advice` 정상 경로에서 CSV 80행 이유문구(`csv_reason`)를 항상 응답에 포함
- LLM 실패 fallback 경로에서도 `csv_reason`과 `reason`을 함께 반환

## 배경
MAIN BFF가 히어로 이유 문구를 `csv_reason` 우선으로 매핑하는데, AI 응답에 해당 키가 누락되면 MAIN에서 이유 문구가 비어 보일 수 있었습니다.

## 검증
- `python3 -m py_compile main.py app/services.py`
