### PR TITLE
fix: prevent llm timeout thread buildup on repeated requests

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -1805,6 +1805,7 @@ async def get_medical_advice(station_name: str, user_profile: Dict[str, Any]) ->
                 {"role": "user", "content": user_prompt}
             ],
             response_format={"type": "json_object"},
+            timeout=max(ADVICE_LLM_TIMEOUT_MS, 1) / 1000,
         )
 
         timings["llm_ms"] = round((perf_counter() - llm_started_at) * 1000, 1)


### PR DESCRIPTION
## Summary
- add explicit OpenAI network timeout parameter to `chat.completions.create`
- prevent lingering long-running SDK calls in worker threads after outer timeout cancellation
- stabilize repeated requests that previously hit client-side timeout spikes during sustained traffic

## Validation
- `python -m py_compile app/services.py`
- repeated local advice calls (14 sequential)
  - before this patch: intermittent client timeout spikes observed in sustained loops
  - after this patch: 14/14 HTTP 200, p50 ~2.24s, no 8s client timeout failures
